### PR TITLE
Fix undertermined execution behavior

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -601,7 +601,8 @@ class vector_downward {
   }
 
   inline uint8_t *make_space(size_t len) {
-    cur_ -= ensure_space(len);
+    size_t space = ensure_space(len);
+    cur_ -= space;
     return cur_;
   }
 


### PR DESCRIPTION
Fix for the issue #4744: Ambiguous side-effect execution on vector_downward::make_space() method.
C++ does not impose evaluation order on the two expressions on the right side of the assignment, so compiler can freely decide. As ensure_space() method can change the value of "cur_" variable, the result of the subtraction may be different depending on the evaluation order, which is ambiguous in C++.
In order to make this code deterministic and correct, cur_ must be evaluated after ensure_space() is called.